### PR TITLE
Issue037 mesh sample bs1

### DIFF
--- a/bsplines2d/_class02_BSplines2D.py
+++ b/bsplines2d/_class02_BSplines2D.py
@@ -944,6 +944,7 @@ class BSplines2D(Previous):
         dref_vectorZ=None,
         dref_vectorU=None,
         ref_vector_strategy=None,
+        uniform=None,
         # interpolation
         val_out=None,
         nan0=None,
@@ -976,6 +977,7 @@ class BSplines2D(Previous):
             dref_vectorZ=dref_vectorZ,
             dref_vectorU=dref_vectorU,
             ref_vector_strategy=ref_vector_strategy,
+            uniform=uniform,
             # interpolation
             val_out=val_out,
             nan0=nan0,

--- a/bsplines2d/_class02_interpolate.py
+++ b/bsplines2d/_class02_interpolate.py
@@ -148,10 +148,7 @@ def interpolate(
         wm = coll._which_mesh
         wbs = coll._which_bsplines
         deg = coll.dobj[wbs][keybs]['deg']
-        print(keys, keybs, keym, deg, x0)
         if x0 is None and res is None and deg == 1:
-            print()
-            print(keys, keybs, keym)    # DB
             subbs = coll.dobj[wm][keym].get('subbs')
             if (
                 submesh is True

--- a/bsplines2d/_class02_interpolate.py
+++ b/bsplines2d/_class02_interpolate.py
@@ -144,6 +144,22 @@ def interpolate(
                 np.array([doutline['x0']['data'], doutline['x1']['data']]).T
             )
 
+        # no x0 + no res + deg = 1 bsplines => x0 = knots
+        wbs = coll._which_bsplines
+        deg = coll.dobj[wbs][keybs]['deg']
+        print(keys, keybs, keym, deg, x0)
+        if x0 is None and res is None and deg == 1:
+            print()
+            print(keys, keybs, keym)    # DB
+            kx = coll.dobj[wbs][keybs]['knots']
+            x0 = coll.ddata[kx[0]]['data']
+            if len(kx) == 2:
+                print('2d')
+                x1 = coll.ddata[kx[0]]['data']
+                x0 = np.repeat(x0[:, None], x1.size, axis=1)
+                x1 = np.repeat(x1[None, :], x0.shape[0], axis=0)
+                grid = False
+
         # ---------------
         # no x0 => mesh
 

--- a/bsplines2d/_class02_interpolate.py
+++ b/bsplines2d/_class02_interpolate.py
@@ -144,26 +144,32 @@ def interpolate(
                 np.array([doutline['x0']['data'], doutline['x1']['data']]).T
             )
 
-        # no x0 + no res + deg = 1 bsplines => x0 = knots
+        # # no x0 + no res + deg = 1 bsplines => x0 = knots
+        wm = coll._which_mesh
         wbs = coll._which_bsplines
         deg = coll.dobj[wbs][keybs]['deg']
         print(keys, keybs, keym, deg, x0)
         if x0 is None and res is None and deg == 1:
             print()
             print(keys, keybs, keym)    # DB
-            kx = coll.dobj[wbs][keybs]['knots']
-            x0 = coll.ddata[kx[0]]['data']
-            if len(kx) == 2:
-                print('2d')
-                x1 = coll.ddata[kx[0]]['data']
-                x0 = np.repeat(x0[:, None], x1.size, axis=1)
-                x1 = np.repeat(x1[None, :], x0.shape[0], axis=0)
-                grid = False
+            subbs = coll.dobj[wm][keym].get('subbs')
+            if (
+                submesh is True
+                and subbs is not None
+                and coll.dobj[wbs][subbs]['deg'] == 1
+            ):
+                bsx0 = subbs
+            elif submesh is False or subbs is None:
+                bsx0 = keybs
+
+            kx01 = coll.dobj[bsx0]['apex']
+            x0 = coll.ddata[kx01[0]]['data']
+            if len(kx01) == 2:
+                x1 = coll.ddata[kx01[1]]['data']
 
         # ---------------
         # no x0 => mesh
 
-        wm = coll._which_mesh
         if x0 is None:
             if submesh is True:
                 km = coll.dobj[wm][keym]['submesh']

--- a/bsplines2d/_class02_interpolate_all.py
+++ b/bsplines2d/_class02_interpolate_all.py
@@ -280,19 +280,22 @@ def _check(
         # particular case
         if dres[k0]['x0'] is None and dres[k0]['res'] is None:
             ldeg1 = [bs for bs in dres[k0][wbs] if coll.dobj[wbs][bs]['deg'] == 1]
+
             if len(ldeg1) == 1:
                 km = coll.dobj[wbs][ldeg1[0]][wm]
-                if submesh and coll.dobj[wm][km]['submesh'] is not None:
-                    subkey = coll.dobj[wm][km]['subkey'][0]
-                    if len(coll.ddata[subkey][wbs]) == 1:
-                        subbs = coll.ddata[subkey][wbs][0]
-                        if coll.dobj[wbs][subbs]['deg'] == 1:
-                            ldeg1[0] = subbs
-                        else:
-                            ldeg1 = None
-                    else:
-                        ldeg1 = None
+                subbs = coll.dobj[wm][km].get('subbs')
+                if (
+                    submesh is True
+                    and subbs is not None
+                    and coll.dobj[wbs][subbs]['deg'] == 1
+                ):
+                    ldeg1[0] = subbs
+                elif submesh is False or subbs is None:
+                    pass
+                else:
+                    ldeg1 = None
 
+                # get default x0, x1
                 if ldeg1 is not None:
                     kx = coll.dobj[wbs][ldeg1[0]]['apex']
                     dres[k0]['x0'] = coll.ddata[kx[0]]['data']
@@ -300,12 +303,16 @@ def _check(
                         dres[k0]['x1'] = coll.ddata[kx[1]]['data']
 
     # -------- DEBUG ------
-    # lstr = [
-    #     f"\t- {k0}: {v0['x0'].size if v0['x0'] is not None else None} and "
-    #     f"{v0['x1'].size if v0['x1'] is not None else None}"
-    #     for k0, v0 in dres.items()
-    # ]
-    # print("\n".join(lstr))     # DB
+    lstr = [
+        f"\t- {k0}: {v0['x0'].size if v0['x0'] is not None else None} and "
+        f"{v0['x1'].size if v0['x1'] is not None else None}"
+        for k0, v0 in dres.items()
+    ]
+    msg = (
+        "The following resolutions x0 are identified:\n"
+        + "\n".join(lstr)
+    )
+    print(msg)    # DB
     # ----- DEBUG END ------
 
     # ----------

--- a/bsplines2d/_class02_interpolate_all.py
+++ b/bsplines2d/_class02_interpolate_all.py
@@ -213,7 +213,7 @@ def _check(
     dbs = {}
     for ii, bs in enumerate(lbs):
         km = coll.dobj[wbs][bs][wm]
-        if submesh and coll.dobj[wm][km]['submesh'] is not None:
+        if submesh is True and coll.dobj[wm][km]['submesh'] is not None:
             km = coll.dobj[wm][km]['submesh']
         dbs[bs] = km
 
@@ -278,10 +278,23 @@ def _check(
         if dres[k0]['x0'] is None and dres[k0]['res'] is None:
             ldeg1 = [bs for bs in dres[k0][wbs] if coll.dobj[wbs][bs]['deg'] == 1]
             if len(ldeg1) == 1:
-                kx = coll.dobj[wbs][ldeg1[0]]['apex']
-                dres[k0]['x0'] = coll.ddata[kx[0]]['data']
-                if len(kx) == 2:
-                    dres[k0]['x1'] = coll.ddata[kx[1]]['data']
+                km = coll.dobj[wbs][ldeg1[0]][wm]
+                if submesh and coll.dobj[wm][km]['submesh'] is not None:
+                    subkey = coll.dobj[wm][km]['subkey'][0]
+                    if len(coll.ddata[subkey][wbs]) == 1:
+                        subbs = coll.ddata[subkey][wbs][0]
+                        if coll.dobj[wbs][subbs]['deg'] == 1:
+                            ldeg1[0] = subbs
+                        else:
+                            ldeg1 = None
+                    else:
+                        ldeg1 = None
+
+                if ldeg1 is not None:
+                    kx = coll.dobj[wbs][ldeg1[0]]['apex']
+                    dres[k0]['x0'] = coll.ddata[kx[0]]['data']
+                    if len(kx) == 2:
+                        dres[k0]['x1'] = coll.ddata[kx[1]]['data']
 
     # ----------
     # coll2

--- a/bsplines2d/_class02_interpolate_all.py
+++ b/bsplines2d/_class02_interpolate_all.py
@@ -29,6 +29,9 @@ def interpolate_all_bsplines(
     val_out=None,
     nan0=None,
 ):
+    """ Interpolate along all bsplines for multiple keys
+
+    """
 
     # ----------
     # check
@@ -295,6 +298,15 @@ def _check(
                     dres[k0]['x0'] = coll.ddata[kx[0]]['data']
                     if len(kx) == 2:
                         dres[k0]['x1'] = coll.ddata[kx[1]]['data']
+
+    # -------- DEBUG ------
+    # lstr = [
+    #     f"\t- {k0}: {v0['x0'].size if v0['x0'] is not None else None} and "
+    #     f"{v0['x1'].size if v0['x1'] is not None else None}"
+    #     for k0, v0 in dres.items()
+    # ]
+    # print("\n".join(lstr))     # DB
+    # ----- DEBUG END ------
 
     # ----------
     # coll2

--- a/bsplines2d/_class02_interpolate_all.py
+++ b/bsplines2d/_class02_interpolate_all.py
@@ -303,16 +303,16 @@ def _check(
                         dres[k0]['x1'] = coll.ddata[kx[1]]['data']
 
     # -------- DEBUG ------
-    lstr = [
-        f"\t- {k0}: {v0['x0'].size if v0['x0'] is not None else None} and "
-        f"{v0['x1'].size if v0['x1'] is not None else None}"
-        for k0, v0 in dres.items()
-    ]
-    msg = (
-        "The following resolutions x0 are identified:\n"
-        + "\n".join(lstr)
-    )
-    print(msg)    # DB
+    # lstr = [
+    #     f"\t- {k0}: {v0['x0'].size if v0['x0'] is not None else None} and "
+    #     f"{v0['x1'].size if v0['x1'] is not None else None}"
+    #     for k0, v0 in dres.items()
+    # ]
+    # msg = (
+    #     "The following resolutions x0 are identified:\n"
+    #     + "\n".join(lstr)
+    # )
+    # print(msg)    # DB
     # ----- DEBUG END ------
 
     # ----------

--- a/bsplines2d/_class02_plot_as_profile2d.py
+++ b/bsplines2d/_class02_plot_as_profile2d.py
@@ -33,6 +33,7 @@ def plot_as_profile2d(
     dref_vectorZ=None,
     dref_vectorU=None,
     ref_vector_strategy=None,
+    uniform=None,
     # interpolation
     val_out=None,
     nan0=None,
@@ -139,6 +140,7 @@ def plot_as_profile2d(
                 # ref vector
                 dref_vector=dref_vectorZ,
                 ref_vector_strategy=ref_vector_strategy,
+                uniform=uniform,
                 # details
                 plot_details=plot_details,
                 # plotting
@@ -766,6 +768,7 @@ def _plot_submesh(
     # ref vetcor
     dref_vector=None,
     ref_vector_strategy=None,
+    uniform=None,
     # plot_details
     plot_details=None,
     # figure
@@ -816,6 +819,7 @@ def _plot_submesh(
         interp=interp,
         label=True,
         inplace=True,
+        uniform=uniform,
         **dkeys,
     )
 

--- a/bsplines2d/_class02_plot_as_profile2d.py
+++ b/bsplines2d/_class02_plot_as_profile2d.py
@@ -959,9 +959,15 @@ def _plot_profile2d_polar_add_radial(
 
     kr2d = coll.dobj[wm][keym]['subkey'][0]
     kr = coll.dobj[wm][keym]['knots'][0]
-    rr = coll.ddata[kr]['data']
-    rad = np.linspace(rr[0], rr[-1], 10*rr.size)
 
+    # special case of deg = 1 => use knots directly
+    rr = coll.ddata[kr]['data']
+    if coll.dobj[wbs][keybs]['deg'] == 1:
+        rad = rr
+    else:
+        rad = np.linspace(rr[0], rr[-1], 10*rr.size)
+
+    # temporary keys
     refr = f'{key}_nradius'
     kradius = f'{key}_radius'
 

--- a/bsplines2d/_class02_plot_as_profile2d.py
+++ b/bsplines2d/_class02_plot_as_profile2d.py
@@ -864,7 +864,8 @@ def _plot_submesh(
                     lw=2,
                     c=color_dict,
                 )
-            else:
+
+            elif collax.ddata[lkradial[ii]]['data'].ndim == 2:
                 l0, = ax.plot(
                     collax.ddata[kradius]['data'],
                     collax.ddata[lkradial[ii]]['data'][0, :],
@@ -883,6 +884,12 @@ def _plot_submesh(
                     axes=kax,
                     ind=0,
                 )
+            else:
+                msg = (
+                    "spectral, radial and time-dependent profile2d"
+                    " plotting not implemented yet!"
+                )
+                raise NotImplementedError(msg)
 
         if lkdet is not None:
             for ii in range(len(lkdet)):


### PR DESCRIPTION
Main changes:
----------------
* Now all `deg=1` `bsplines`, when called for interpolation / plotting, are interpolated by default on the same sample points as their underlying `mesh` `knots`
* Makes sense for `deg=1` because anyways the space between knots is linearly interpolated
* Also, propagated upwards `uniform=bool` when choosing `keyX`, `keyY`, `keyZ` for plotting


Issues:
-------
Fixes, in devel, issue #37 
