### PR TITLE
Prepare 0.0.18

### DIFF
--- a/bsplines2d/version.py
+++ b/bsplines2d/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '0.0.15'
+__version__ = '0.0.16'

--- a/bsplines2d/version.py
+++ b/bsplines2d/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '0.0.16'
+__version__ = '0.0.17'

--- a/bsplines2d/version.py
+++ b/bsplines2d/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '0.0.14'
+__version__ = '0.0.15'

--- a/bsplines2d/version.py
+++ b/bsplines2d/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '0.0.17'
+__version__ = '0.0.18'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ scipy
 matplotlib
 astropy
 contourpy
-datastock>=0.0.39
+datastock>=0.0.42

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         "matplotlib",
         "astropy",
         "contourpy",
-        "datastock>=0.0.39",
+        "datastock>=0.0.42",
     ],
     python_requires=">=3.6",
 


### PR DESCRIPTION
Main changes:
----------------

retro-compatible fix of new scipy bsplines interpolation + warning
#88 
