### PR TITLE
Issue086 outline triangular

### DIFF
--- a/bsplines2d/tests/test_01_Mesh2D.py
+++ b/bsplines2d/tests/test_01_Mesh2D.py
@@ -106,11 +106,11 @@ class Test01_BSplines2D():
     def test05_add_mesh_rect_variable_crop(self):
         test_input._add_rect_variable_crop(self.bs)
 
-    def test06_add_mesh_rect_variable_crop(self):
-        test_input._add_rect_variable_crop(self.bs)
+    def test06_add_mesh_rect_crop_from_knots(self):
+        test_input._add_rect_crop_from_knots(self.bs)
 
-    def test07_add_mesh_rect_variable_crop(self):
-        test_input._add_rect_variable_crop(self.bs)
+    def test07_add_mesh_rect_variable_crop_from_knots(self):
+        test_input._add_rect_variable_crop_from_knots(self.bs)
 
     # ##############
     #  mesh 2d tri
@@ -139,158 +139,168 @@ class Test01_BSplines2D():
         test_input._select_mesh_elements(self.bs, nd='2d', kind='tri')
 
     # ##############
+    #  mesh outline
+    # ##############
+
+    def test14_get_mesh_outline_rect(self):
+        test_input._get_mesh_outline_rect(self.bs)
+
+    def test15_get_mesh_outline_tri(self):
+        test_input._get_mesh_outline_tri(self.bs)
+
+    # ##############
     #  sample
     # ##############
 
-    def test14_sample_mesh_1d(self):
+    def test16_sample_mesh_1d(self):
         test_input._sample_mesh(self.bs, nd='1d', kind=None)
 
-    def test15_sample_mesh_rect(self):
+    def test17_sample_mesh_rect(self):
         test_input._sample_mesh(self.bs, nd='2d', kind='rect')
 
-    def test16_sample_mesh_tri(self):
+    def test18_sample_mesh_tri(self):
         test_input._sample_mesh(self.bs, nd='2d', kind='tri')
 
     # ##############
     #  plot
     # ##############
 
-    def test17_plot_mesh_1d(self):
+    def test19_plot_mesh_1d(self):
         test_input._plot_mesh(self.bs, nd='1d', kind=None)
 
-    def test18_plot_mesh_rect(self):
+    def test20_plot_mesh_rect(self):
         test_input._plot_mesh(self.bs, nd='2d', kind='rect')
 
-    def test19_plot_mesh_tri(self):
+    def test21_plot_mesh_tri(self):
         test_input._plot_mesh(self.bs, nd='2d', kind='tri')
 
     # ##############
     #  add bsplines
     # ##############
 
-    def test20_add_bsplines_1d(self):
+    def test22_add_bsplines_1d(self):
         test_input._add_bsplines(self.bs, nd='1d')
 
-    def test21_add_bsplines_2d_rect(self):
+    def test23_add_bsplines_2d_rect(self):
         test_input._add_bsplines(self.bs, kind='rect')
 
-    def test22_add_bsplines_2d_tri(self):
+    def test24_add_bsplines_2d_tri(self):
         test_input._add_bsplines(self.bs, kind='tri')
 
     # ##############
     #  select bsplines
     # ##############
 
-    def test23_select_bsplines_1d(self):
+    def test25_select_bsplines_1d(self):
         test_input._select_bsplines(self.bs, nd='1d', kind=None)
 
-    def test24_select_bsplines_2d_rect(self):
+    def test26_select_bsplines_2d_rect(self):
         test_input._select_bsplines(self.bs, nd='2d', kind='rect')
 
-    def test25_select_bsplines_2d_tri(self):
+    def test27_select_bsplines_2d_tri(self):
         test_input._select_bsplines(self.bs, nd='2d', kind='tri')
 
     # ###############
     #  add data vs bs
     # ###############
 
-    def test26_add_data_1bs_fix_1d(self, remove=True):
+    def test28_add_data_1bs_fix_1d(self, remove=True):
         test_input._add_data_1bs_fix(self.bs, nd='1d', kind=None, remove=remove)
 
-    def test27_add_data_1bs_fix_2d_rect(self, remove=True):
+    def test29_add_data_1bs_fix_2d_rect(self, remove=True):
         test_input._add_data_1bs_fix(self.bs, nd='2d', kind='rect', remove=remove)
 
-    def test28_add_data_1bs_fix_2d_tri(self, remove=True):
+    def test30_add_data_1bs_fix_2d_tri(self, remove=True):
         test_input._add_data_1bs_fix(self.bs, nd='2d', kind='tri', remove=remove)
 
-    def test29_add_data_1bs_arrays_1d(self, remove=False):
+    def test31_add_data_1bs_arrays_1d(self, remove=False):
         test_input._add_data_1bs_arrays(self.bs, nd='1d', kind=None, remove=remove)
 
-    def test30_add_data_1bs_arrays_2d_rect(self, remove=False):
+    def test32_add_data_1bs_arrays_2d_rect(self, remove=False):
         test_input._add_data_1bs_arrays(self.bs, nd='2d', kind='rect', remove=remove)
 
-    def test31_add_data_1bs_arrays_2d_tri(self, remove=False):
+    def test33_add_data_1bs_arrays_2d_tri(self, remove=False):
         test_input._add_data_1bs_arrays(self.bs, nd='2d', kind='tri', remove=remove)
 
-    def test32_add_data_multibs_arrays(self, remove=False):
+    def test34_add_data_multibs_arrays(self, remove=False):
         test_input._add_data_multibs_arrays(self.bs, remove=remove)
 
     # ##############
     # interp bs
     # ##############
 
-    def test33_interpolate_bsplines_1d(self):
+    def test35_interpolate_bsplines_1d(self):
         test_input._interpolate(self.bs, nd='1d', kind=None, details=False)
 
-    def test34_interpolate_bsplines_1d_details(self):
+    def test36_interpolate_bsplines_1d_details(self):
         test_input._interpolate(self.bs, nd='1d', kind=None, details=True)
 
-    def test35_interpolate_bsplines_2d_rect(self):
+    def test37_interpolate_bsplines_2d_rect(self):
         test_input._interpolate(self.bs, nd='2d', kind='rect', details=False)
 
-    def test36_interpolate_bsplines_2d_rect_details(self):
+    def test38_interpolate_bsplines_2d_rect_details(self):
         test_input._interpolate(self.bs, nd='2d', kind='rect', details=True)
 
-    def test37_interpolate_bsplines_2d_tri(self):
+    def test39_interpolate_bsplines_2d_tri(self):
         test_input._interpolate(self.bs, nd='2d', kind='tri', details=False)
 
-    def test38_interpolate_bsplines_2d_tri_details(self):
+    def test40_interpolate_bsplines_2d_tri_details(self):
         test_input._interpolate(self.bs, nd='2d', kind='tri', details=True)
 
     # ##############
     # binning 1d
     # ##############
 
-    def test39_binning_1d(self):
+    def test41_binning_1d(self):
         test_input._bin_bs(self.bs, nd='1d', kind=None)
 
     # ##############
     # plot bsplines
     # ##############
 
-    def test40_plot_bsplines_1d(self):
+    def test42_plot_bsplines_1d(self):
         pass
 
-    def test41_plot_bsplines_2d_rect(self):
+    def test43_plot_bsplines_2d_rect(self):
         pass
 
-    def test42_plot_bsplines_2d_tri(self):
+    def test44_plot_bsplines_2d_tri(self):
         pass
 
     # ####################
     # add mesh with subkey
     # ####################
 
-    def test43_add_mesh_1d_subkey_1d(self):
+    def test45_add_mesh_1d_subkey_1d(self):
         test_input._add_mesh_1d_subkey(self.bs, nd='1d', kind=None)
 
-    def test44_add_mesh_1d_subkey_rect(self):
+    def test46_add_mesh_1d_subkey_rect(self):
         test_input._add_mesh_1d_subkey(self.bs, nd='2d', kind='rect')
 
-    def test45_add_mesh_1d_subkey_tri(self):
+    def test47_add_mesh_1d_subkey_tri(self):
         test_input._add_mesh_1d_subkey(self.bs, nd='2d', kind='tri')
 
-    def test46_add_mesh_2d_rect_subkey_rect(self):
+    def test48_add_mesh_2d_rect_subkey_rect(self):
         test_input._add_mesh_2d_rect_subkey(self.bs, nd='2d', kind='rect')
 
-    def test47_add_mesh_2d_rect_subkey_tri(self):
+    def test49_add_mesh_2d_rect_subkey_tri(self):
         test_input._add_mesh_2d_rect_subkey(self.bs, nd='2d', kind='tri')
 
-    def test48_add_mesh_2d_rect_var_subkey_rect(self):
+    def test50_add_mesh_2d_rect_var_subkey_rect(self):
         test_input._add_mesh_2d_rect_subkey(self.bs, nd='2d', kind='rect')
 
     # ################################
     # add bsplines on mesh with subkey
     # ################################
 
-    def test49_add_bsplines_subkey(self):
+    def test51_add_bsplines_subkey(self):
         test_input._add_bsplines(self.bs, subkey=True)
 
     # ################################
     # add data on bsplines with subkey
     # ################################
 
-    def test50_add_data_subkey(self):
+    def test52_add_data_subkey(self):
         test_input._add_data_multibs_arrays(
             self.bs,
             nd=None,
@@ -303,7 +313,7 @@ class Test01_BSplines2D():
     # interpolate data with subkey
     # ################################
 
-    def test51_interpolate_subkey_1d(self):
+    def test53_interpolate_subkey_1d(self):
         test_input._interpolate(
             self.bs,
             nd='1d',
@@ -320,14 +330,14 @@ class Test01_BSplines2D():
     # interpolate data with subkey
     # ################################
 
-    def test53_plot_as_profile2d(self):
+    def test54_plot_as_profile2d(self):
         test_input._plot_as_profile2d(
             self.bs,
             nd='2d',
             kind=None,
         )
 
-    def test54_plot_as_profile2d_compare(self):
+    def test55_plot_as_profile2d_compare(self):
         test_input._plot_as_profile2d_compare(
             self.bs,
             nd='2d',
@@ -338,31 +348,31 @@ class Test01_BSplines2D():
     # operators
     # ################################
 
-    def test55_operators_1d(self):
+    def test56_operators_1d(self):
         test_input._get_operators(
             self.bs,
             nd='1d',
             kind=None,
         )
 
-    def test56_operators_2d_rect(self):
+    def test57_operators_2d_rect(self):
         test_input._get_operators(
             self.bs,
             nd='2d',
             kind='rect',
         )
 
-    def test57_operators_2d_tri(self):
+    def test58_operators_2d_tri(self):
         pass
 
-    def test58_operators_1d_subkey(self):
+    def test59_operators_1d_subkey(self):
         pass
 
     # ################################
     # saving / loading
     # ################################
 
-    def test59_saveload_equal(self):
+    def test60_saveload_equal(self):
 
         # save
         pfe = self.bs.save(return_pfe=True)
@@ -376,7 +386,7 @@ class Test01_BSplines2D():
         # equal
         assert self.bs == out
 
-    def test60_saveload_coll(self):
+    def test61_saveload_coll(self):
 
         # save
         pfe = self.bs.save(return_pfe=True)

--- a/bsplines2d/tests/test_input.py
+++ b/bsplines2d/tests/test_input.py
@@ -143,6 +143,69 @@ def _add_tri_delaunay(bsplines, key=None):
 
 #######################################################
 #
+#     mesh outlines
+#
+#######################################################
+
+
+def _get_mesh_outline_rect(coll):
+
+    # -----------------------------
+    # check existence of mesh rect
+    # -----------------------------
+
+    wm = coll._which_mesh
+    lm = [
+        k0 for k0, v0 in coll.dobj.get(wm, {}).items()
+        if v0['type'] == 'rect'
+    ]
+    if len(lm) == 0:
+        _add_rect_uniform(coll)
+        lm = lm = [
+            k0 for k0, v0 in coll.dobj.get(wm, {}).items()
+            if v0['type'] == 'rect'
+        ]
+
+    # -----------------------------
+    # get outline
+    # -----------------------------
+
+    for km in lm:
+        dout = coll.get_mesh_outline(key=km)
+
+    return
+
+
+def _get_mesh_outline_tri(coll):
+
+    # -----------------------------
+    # check existence of mesh rect
+    # -----------------------------
+
+    wm = coll._which_mesh
+    lm = [
+        k0 for k0, v0 in coll.dobj.get(wm, {}).items()
+        if v0['type'] == 'tri'
+    ]
+    if len(lm) == 0:
+        _add_tri_ntri1(coll)
+        lm = lm = [
+            k0 for k0, v0 in coll.dobj.get(wm, {}).items()
+            if v0['type'] == 'tri'
+        ]
+
+    # -----------------------------
+    # get outline
+    # -----------------------------
+
+    for km in lm:
+        dout = coll.get_mesh_outline(key=km)
+
+    return
+
+
+#######################################################
+#
 #     Add variable meshes
 #
 #######################################################


### PR DESCRIPTION
Main changes:
----------------

* `get_mesh_outline()` implemented 
     - for triangular meshes too
     - now return dict containing both `indices` of nodes and coordinates `x0` and `x1`

* Unit tests implemented accordingly

Issues:
--------

Fixes, in devel, issue #86 


Examples:
------------

```
import bsplines2d as bs2

test = bs2.tests.test_01_Mesh2D.Test01_BSplines2D()

test.setup_class()

test.setup_method()

test.test08_add_mesh_tri_ntri1()

coll = test.bs

dax = coll.plot_mesh()

dout = coll.get_mesh_outline()

dax['cross']['handle'].plot(dout['x0']['data'], dout['x1']['data'], '.-r', label='outline')

plt.legend()
```

![image](https://github.com/user-attachments/assets/8041e073-9322-4f79-8b81-7a0a07ccf692)



