### PR TITLE
datastock >= 0.0.46 & error msg

### DIFF
--- a/bsplines2d/_class01_sample.py
+++ b/bsplines2d/_class01_sample.py
@@ -428,8 +428,8 @@ def _get_res(
 
         if not (np.isscalar(res) and res > 0.):
             msg = (
-                f"Arg res must be a positive float!\n"
-                "Provided: {res}"
+                "Arg res must be a positive float!\n"
+                f"Provided: {res}"
             )
             raise Exception(msg)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ scipy
 matplotlib
 astropy
 contourpy
-datastock>=0.0.45
+datastock>=0.0.46

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         "matplotlib",
         "astropy",
         "contourpy",
-        "datastock>=0.0.45",
+        "datastock>=0.0.46",
     ],
     python_requires=">=3.6",
 


### PR DESCRIPTION
Main changes:
----------------

* Updated dependency to `datastock >= 0.0.46`

* Fixed error mesh in mesh sampling


Issues:
--------

Fixes, in devel:
* #85 
* #101 