### PR TITLE
[#138] Fixed indexing in operator _D1_Deg0_2d()

### DIFF
--- a/bsplines2d/_class01_plot.py
+++ b/bsplines2d/_class01_plot.py
@@ -69,7 +69,7 @@ def plot_mesh(
             key=key,
             ind_knot=ind_knot,
             ind_cent=ind_cent,
-            #units=units,
+            # units=units,
             return_neighbours=return_neighbours,
             nmax=nmax,
             color=color,
@@ -102,15 +102,15 @@ def plot_mesh(
         # possibly time-varying mesh
         raise NotImplementedError()
         # return _plot_mesh_2d_polar(
-            # coll=coll,
-            # key=key,
-            # nmax=nmax,
-            # color=color,
-            # dax=dax,
-            # fs=fs,
-            # dmargin=dmargin,
-            # dleg=dleg,
-            # connect=connect,
+        # coll=coll,
+        # key=key,
+        # nmax=nmax,
+        # color=color,
+        # dax=dax,
+        # fs=fs,
+        # dmargin=dmargin,
+        # dleg=dleg,
+        # connect=connect,
         # )
 
 
@@ -131,20 +131,45 @@ def _plot_mesh_check(
     dleg=None,
 ):
 
+    # ----------
+    # key
+    # ----------
+
+    # which
+    wm = coll._which_mesh
+    wbs = coll._which_bsplines
+
+    # lok
+    lok_mesh = list(coll.dobj.get(wm, {}).keys())
+    lok_bs = list(coll.dobj.get(wbs, {}).keys())
+
     # key
     key = ds._generic_check._check_var(
         key, 'key',
         default=None,
         types=str,
-        allowed=list(coll.dobj.get(coll._which_mesh, {}).keys()),
+        allowed=lok_mesh + lok_bs,
     )
 
+    # bs => mesh
+    if key in lok_bs:
+        key = coll.dobj[wbs][key]['mesh']
+
+    # derive
     nd = coll.dobj[coll._which_mesh][key]['nd']
     mtype = coll.dobj[coll._which_mesh][key]['type']
+
+    # ----------
+    # crop, bck
+    # ----------
 
     # crop, bck
     crop = ds._generic_check._check_var(crop, 'crop', default=True, types=bool)
     bck = ds._generic_check._check_var(bck, 'bck', default=True, types=bool)
+
+    # ----------
+    # return_neighbours, cents, knots
+    # ----------
 
     if mtype in ['rect', 'tri']:
         return_neighbours = True
@@ -168,6 +193,10 @@ def _plot_mesh_check(
         )
         if return_neighbours is False:
             ind_cent = [ind_cent]
+
+    # ----------
+    # other parameters
+    # ----------
 
     # color
     if color is None:

--- a/bsplines2d/_class02_BSplines2D.py
+++ b/bsplines2d/_class02_BSplines2D.py
@@ -20,6 +20,7 @@ from . import _class02_line_tracing as _line_tracing
 from . import _class02_interpolate as _interpolate
 from . import _class02_interpolate_all as _interpolate_all
 from . import _class02_operators as _operators
+from . import _class02_plot_operators as _plot_operators
 from . import _class02_plot_as_profile2d as _plot_as_profile2d
 from . import _class02_plot_as_profile2d_compare as _plot_as_profile2d_compare
 from . import _saveload
@@ -81,7 +82,7 @@ class BSplines2D(Previous):
             )
         else:
             dref, ddata, dobj = _compute._mesh2Dpolar_bsplines(
-                coll=self, keym=keym, keybs=keybs, deg=deg, # angle=angle,
+                coll=self, keym=keym, keybs=keybs, deg=deg,     # angle=angle,
             )
 
         # --------------
@@ -384,7 +385,6 @@ class BSplines2D(Previous):
             dsolver=dsolver,
         )
 
-
     # -----------------
     # Integration operators
     # ------------------
@@ -475,6 +475,47 @@ class BSplines2D(Previous):
             key_store=key_store,
             # returnas
             returnas=returnas,
+        )
+
+    def plot_bsplines_operator(
+        self,
+        key=None,
+        operator=None,
+        geometry=None,
+        crop=None,
+        # store vs return
+        return_param=None,
+        # specific to deg = 0
+        centered=None,
+        # to return gradR, gradZ, for D1N2 deg 0, for tomotok
+        returnas_element=None,
+        # plotting
+        dax=None,
+        fs=None,
+        dmargin=None,
+        fontsize=None,
+    ):
+        """ Plot desired operator, without adding to the Collection
+
+        Return dax
+        """
+
+        return _plot_operators.main(
+            coll=self,
+            key=key,
+            operator=operator,
+            geometry=geometry,
+            crop=crop,
+            return_param=return_param,
+            # specific to deg = 0
+            centered=centered,
+            # to return gradR, gradZ, for D1N2 deg 0, for tomotok
+            returnas_element=returnas_element,
+            # plotting
+            dax=dax,
+            fs=fs,
+            dmargin=dmargin,
+            fontsize=fontsize,
         )
 
     # -----------------

--- a/bsplines2d/_class02_plot_operators.py
+++ b/bsplines2d/_class02_plot_operators.py
@@ -1,0 +1,262 @@
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+import datastock as ds
+
+
+# ###########################################
+# ###########################################
+#               Main
+# ###########################################
+
+
+def main(
+    coll=None,
+    key=None,
+    operator=None,
+    geometry=None,
+    crop=None,
+    # store vs return
+    return_param=None,
+    # specific to deg = 0
+    centered=None,
+    # to return gradR, gradZ, for D1N2 deg 0, for tomotok
+    returnas_element=None,
+    # plotting
+    dax=None,
+    fs=None,
+    dmargin=None,
+    fontsize=None,
+):
+
+    # ------------
+    # check inputs
+    # ------------
+
+    key, operator = _check(**locals())
+
+    # ------------
+    # get operator
+    # ------------
+
+    dout = coll.add_bsplines_operator(
+        key=key,
+        operator=operator,
+        geometry=geometry,
+        crop=crop,
+        store=False,
+        returnas=True,
+        return_param=return_param,
+        # specific to deg = 0
+        centered=centered,
+        # to return gradR, gradZ, for D1N2 deg 0, for tomotok
+        returnas_element=returnas_element,
+    )
+
+    # ------------
+    # prepare axes
+    # ------------
+
+    if dax is None:
+        dax = _get_dax(
+            coll=coll,
+            key=key,
+            operator=operator,
+            dmargin=dmargin,
+            fs=fs,
+            fontsize=fontsize,
+        )
+
+    dax = ds._generic_check._check_dax(dax)
+
+    # ------------
+    # plot
+    # ------------
+
+    if operator == 'D1N2':
+
+        _plot_D1N2(dax=dax, dout=dout)
+
+    return dax
+
+
+# ###########################################
+# ###########################################
+#               Check
+# ###########################################
+
+
+def _check(
+    coll=None,
+    key=None,
+    operator=None,
+    # unused
+    **kwdargs,
+):
+
+    # -------------
+    # key
+    # -------------
+
+    wbs = coll._which_bsplines
+    lok = list(coll.dobj.get(wbs, {}).keys())
+    key = ds._generic_check._check_var(
+        key, 'key',
+        types=str,
+        allowed=lok,
+    )
+
+    # -------------
+    # operator
+    # -------------
+
+    lok = ['D1N2']
+    operator = ds._generic_check._check_var(
+        operator, 'operator',
+        types=str,
+        allowed=lok,
+        extra_msg="Not implemented for operator '{operator}'!\n"
+    )
+
+    return key, operator
+
+
+# ###########################################
+# ###########################################
+#               get_dax
+# ###########################################
+
+
+def _get_dax(
+    coll=None,
+    key=None,
+    operator=None,
+    fs=None,
+    fontsize=None,
+    dmargin=None,
+):
+
+    # ------------
+    # check inputs
+    # ------------
+
+    # dmargin
+    if dmargin is None:
+        dmargin = {
+            'left': 0.08, 'right': 0.95,
+            'bottom': 0.08, 'top': 0.9,
+            'hspace': 0.1, 'wspace': 0.2,
+        }
+
+    # fontsize
+    fontsize = float(ds._generic_check._check_var(
+        fontsize, 'fontsize',
+        types=(int, float),
+        sign='>0',
+        default=14,
+    ))
+
+    if fs is None:
+        fs = (15, 10)
+
+    # ------------
+    # figure
+    # ------------
+
+    fig = plt.figure(figsize=fs)
+
+    wbs = coll._which_bsplines
+    tit = (
+        f"Operator '{operator}' for {wbs}'{key}'"
+    )
+    fig.suptitle(tit, size=fontsize + 2, fontweight='bold')
+
+    dax = {}
+
+    # ------------
+    # D1N2
+    # ------------
+
+    if operator == 'D1N2':
+
+        gs = gridspec.GridSpec(ncols=2, nrows=1, **dmargin)
+
+        # gradR
+        ax0 = fig.add_subplot(gs[0, 0])
+        ax0.set_title(
+            r'$tMM0 = \nabla^T_R\nabla_R$',
+            fontsize=fontsize,
+            fontweight='bold',
+        )
+        ax0.set_xlabel(
+            'bspline index',
+            fontsize=fontsize,
+            fontweight='bold',
+        )
+        ax0.set_ylabel(
+            'bspline index',
+            fontsize=fontsize,
+            fontweight='bold',
+        )
+
+        dax['gradR'] = {'handle': ax0}
+
+        # gradZ
+        ax = fig.add_subplot(gs[0, 1], sharex=ax0, sharey=ax0)
+        ax.set_title(
+            r'$tMM1 = \nabla^T_Z\nabla_Z$',
+            fontsize=fontsize,
+            fontweight='bold',
+        )
+        ax.set_xlabel(
+            'bspline index',
+            fontsize=fontsize,
+            fontweight='bold',
+        )
+        ax.set_ylabel(
+            'bspline index',
+            fontsize=fontsize,
+            fontweight='bold',
+        )
+
+        dax['gradZ'] = {'handle': ax}
+
+    return dax
+
+
+# ###########################################
+# ###########################################
+#               D1N2
+# ###########################################
+
+
+def _plot_D1N2(
+    dax=None,
+    dout=None,
+):
+
+    # ------------
+    # gradR
+    # ------------
+
+    for kax, kdata in [('gradR', 'tMM0'), ('gradZ', 'tMM1')]:
+
+        if dax.get(kax) is not None:
+            ax = dax[kax]['handle']
+
+            # max value
+            vmax = np.max(np.abs(dout[kdata]['data']))
+
+            # imshow
+            ax.imshow(
+                dout[kdata]['data'].todense(),
+                origin='upper',
+                interpolation='nearest',
+                cmap=plt.cm.seismic,
+                vmax=vmax,
+                vmin=-vmax,
+            )
+
+    return

--- a/bsplines2d/_utils_bsplines_operators.py
+++ b/bsplines2d/_utils_bsplines_operators.py
@@ -543,12 +543,12 @@ def _D1_Deg0_2d(
 
     # iterate on each type of point in Z
     for ir, iz in zip(*npZ.nonzero()):
-        iflat = ir + iz*nx
+        iflat = iz + ir*ny
         dZi = 1./(centsZ[iz + 1] - centsZ[iz])
         datadZ[iflat, iflat] = -dZi
         datadZ[iflat, iflat + 1] = dZi
     for ir, iz in zip(*nmZ.nonzero()):
-        iflat = ir + iz*nx
+        iflat = iz + ir*ny
         dZi = 1./(centsZ[iz] - centsZ[iz - 1])
         datadZ[iflat, iflat - 1] = -dZi
         datadZ[iflat, iflat] = dZi
@@ -582,7 +582,7 @@ def _D1_Deg2(
     knots_mult=None,
     nbs=None,
 ):
-    grad = np.zeros((nbs-1, nbs), dtype=float)
+    # grad = np.zeros((nbs-1, nbs), dtype=float)
 
     raise NotImplementedError()
 

--- a/bsplines2d/_utils_bsplines_operators.py
+++ b/bsplines2d/_utils_bsplines_operators.py
@@ -501,15 +501,15 @@ def _D1_Deg0_2d(
 
         # iterate on each type of point in R
         for ir, iz in zip(*n2R.nonzero()):
-            iflat = ir + iz*nx
+            iflat = iz + ir*ny
             dRi = 1./(centsR[ir + 1] - centsR[ir - 1])
-            datadR[iflat, iflat - 1] = -dRi
-            datadR[iflat, iflat + 1] = dRi
+            datadR[iflat, iflat - ny] = -dRi
+            datadR[iflat, iflat + ny] = dRi
         for ir, iz in zip(*n2Z.nonzero()):
-            iflat = ir + iz*nx
+            iflat = iz + ir*ny
             dZi = 1./(centsZ[iz + 1] - centsZ[iz - 1])
-            datadZ[iflat, iflat - nx] = -dZi
-            datadZ[iflat, iflat + nx] = dZi
+            datadZ[iflat, iflat - 1] = -dZi
+            datadZ[iflat, iflat + 1] = dZi
     else:
         # points with a neighbours at higher R
         npR = np.copy(cropbs)
@@ -531,14 +531,14 @@ def _D1_Deg0_2d(
 
     # iterate on each type of point in R
     for ir, iz in zip(*npR.nonzero()):
-        iflat = ir + iz*nx
+        iflat = iz + ir*ny
         dRi = 1./(centsR[ir + 1] - centsR[ir])
         datadR[iflat, iflat] = -dRi
-        datadR[iflat, iflat + 1] = dRi
+        datadR[iflat, iflat + ny] = dRi
     for ir, iz in zip(*nmR.nonzero()):
-        iflat = ir + iz*nx
+        iflat = iz + ir*ny
         dRi = 1./(centsR[ir] - centsR[ir-1])
-        datadR[iflat, iflat - 1] = -dRi
+        datadR[iflat, iflat - ny] = -dRi
         datadR[iflat, iflat] = dRi
 
     # iterate on each type of point in Z
@@ -546,11 +546,11 @@ def _D1_Deg0_2d(
         iflat = ir + iz*nx
         dZi = 1./(centsZ[iz + 1] - centsZ[iz])
         datadZ[iflat, iflat] = -dZi
-        datadZ[iflat, iflat + nx] = dZi
+        datadZ[iflat, iflat + 1] = dZi
     for ir, iz in zip(*nmZ.nonzero()):
         iflat = ir + iz*nx
         dZi = 1./(centsZ[iz] - centsZ[iz - 1])
-        datadZ[iflat, iflat - nx] = -dZi
+        datadZ[iflat, iflat - 1] = -dZi
         datadZ[iflat, iflat] = dZi
 
     # crop and return


### PR DESCRIPTION
Main changes:
----------------

Following the changes to bsplines indexing implemented in 0.0.28, one of the operator also had to be updated:

* `_utils_bsplines_operators._D0N1_Deg0()`: updated for new indexing

* `plot_mesh(key=key_bs)` now works

* `plot_bsplines_operator(operator='D1N2')` operational


Issues:
-------

Fixes, in devel:
* issue #138 
* issue #137 

Examples:
-----------

```python
import tofu as tf

# test 
test = tf.tests.tests07_inversions.test_01_isotropic.Test01_Inversions()
test.setup_class()
test.setup_method()

# plot bsplines operators
dax = test.coll.plot_bsplines_operator('m1_bs0', centered=False)
dax = test.coll.plot_bsplines_operator('m1_bs1')
dax = test.coll.plot_bsplines_operator('m1_bs2')
```

<img width="1422" height="847" alt="image" src="https://github.com/user-attachments/assets/4a54aae0-d752-4189-a735-5b3420adf4ac" />

<img width="1375" height="850" alt="image" src="https://github.com/user-attachments/assets/7f1491ee-6bd7-4bbb-a0f4-4be03e7519b4" />

<img width="1380" height="850" alt="image" src="https://github.com/user-attachments/assets/51b70b6c-6715-40a8-8446-6433416941f3" />

