### PR TITLE
[#141] Better debugging of sample3d func

### DIFF
--- a/bsplines2d/_class01_sample3d.py
+++ b/bsplines2d/_class01_sample3d.py
@@ -370,7 +370,11 @@ def _get_func_ind_from_domain(
         if debug is True:
 
             # coordinates
-            rr, zz, pp, dV = func_RZphi_from_ind(ind)
+            rr, zz, pp, dV = func_RZphi_from_ind(
+                indr=ind[0, :],
+                indz=ind[1, :],
+                indphi=ind[2, :],
+            )
 
             # title
             tit = (
@@ -425,8 +429,12 @@ def _get_func_ind_from_domain(
                 ax1.fill(phor0, phor1, fc=(0.5, 0.5, 0.5, 0.5))
 
             # points
-            ax0.plot(rr, zz, '.')
-            ax1.plot(rr*np.cos(pp), rr*np.sin(pp), '.')
+            if rr.size == 0:
+                msg = f"\n\t- ind.size = {ind.size}\n\t- rr.size = rr.size\n"
+                print(msg)
+            else:
+                ax0.plot(rr, zz, '.')
+                ax1.plot(rr*np.cos(pp), rr*np.sin(pp), '.')
 
         return ind[0, :], ind[1, :], ind[2, :]
 


### PR DESCRIPTION
Main changes:
----------------

When using `func_ind_from_domain(debug=True)` no crash anymore

Issues:
-------

Fixes, in devel, issue #141 


Examples:
------------

From a tofu use case:

<img width="1225" height="720" alt="image" src="https://github.com/user-attachments/assets/81e531d0-4e16-4743-aa0a-ab23b8669d08" />
<img width="577" height="467" alt="image" src="https://github.com/user-attachments/assets/6eb78c8b-c9f1-4415-b06b-541d3a0ba971" />
