### PR TITLE
`datastock >= 0.0.56` and `dref_vector_name`

### DIFF
--- a/.github/workflows/python-publish-wheel.yml
+++ b/.github/workflows/python-publish-wheel.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-publish-wheel.yml
+++ b/.github/workflows/python-publish-wheel.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-testing-matrix.yml
+++ b/.github/workflows/python-testing-matrix.yml
@@ -18,7 +18,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]   # , windows-latest due to TcK install errors
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # scipy 1.15.3 and 1.16.0 have no wheel for python 3.14
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
 

--- a/.github/workflows/python-testing-matrix.yml
+++ b/.github/workflows/python-testing-matrix.yml
@@ -33,7 +33,7 @@ jobs:
 
     # Install library
     - name: Install the project
-      run: uv sync --all-extras --dev
+      run: uv sync --all-extras --dev --no-build
 
     # Run tests
     - name: Run tests

--- a/.github/workflows/python-testing-matrix.yml
+++ b/.github/workflows/python-testing-matrix.yml
@@ -33,7 +33,7 @@ jobs:
 
     # Install library
     - name: Install the project
-      run: uv sync --all-extras --dev --no-build
+      run: uv sync --all-extras --dev --no-build-package scipy
 
     # Run tests
     - name: Run tests

--- a/.github/workflows/python-testing-matrix.yml
+++ b/.github/workflows/python-testing-matrix.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]   # , windows-latest due to TcK install errors
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
 

--- a/bsplines2d/_class01_checks_2d_tri.py
+++ b/bsplines2d/_class01_checks_2d_tri.py
@@ -160,7 +160,6 @@ def check(
     subbs = subbs0
     submesh = submesh0
 
-
     # --------------
     # to dict
 
@@ -312,7 +311,7 @@ def _check_knotscents(
         assert isinstance(out, np.ndarray)
     except Exception as err:
         msg = str(err) + (
-            "\nArg trifind must return an array of indices when fed with arrays "
+            "\nArg trifind must return an array of indices when fed an arrays "
             "of (R, Z) coordinates!\n"
             f"\ttrifind(np.r_[0], np.r_[0.]) = {out}\n"
             f"\t- ntri = {ntri}\n"
@@ -406,7 +405,7 @@ def _mesh2DTri_conformity(knots=None, indices=None, key=None):
     c0 = np.all(indu >= 0) and indu.size == nknots
 
     # unused knots
-    ino = (~np.in1d(
+    ino = (~np.isin(
         range(0, nknots),
         indu,
         assume_unique=False,
@@ -448,7 +447,7 @@ def _remove_unused_knots(knots, indices, keep):
     indu = np.unique(indices[keep, :])
 
     # cumulated differences in indices
-    keep_pts = np.in1d(np.arange(knots.shape[0]), indu)
+    keep_pts = np.isin(np.arange(knots.shape[0]), indu)
     icum = np.cumsum(~keep_pts)
 
     # update

--- a/bsplines2d/_class02_interpolate.py
+++ b/bsplines2d/_class02_interpolate.py
@@ -227,6 +227,7 @@ def interpolate(
                 coll=coll,
                 kd0=kd0,
                 keys=keys,
+                refbs=coll.dobj[wbs][kbs0]['ref'],
                 ref_com=ref_com,
                 # coordinates
                 x0=x0,
@@ -800,6 +801,7 @@ def _submesh_ref_com(
     coll=None,
     kd0=None,
     keys=None,
+    refbs=None,
     ref_com=None,
     # coordinates
     x0=None,
@@ -809,23 +811,21 @@ def _submesh_ref_com(
     # find possible matches
 
     ref0 = coll.ddata[kd0[0]]['ref']
-    lrcom = [
-        (rr, ref0.index(rr))
-        for ii, rr in enumerate(ref0)
-        if rr in list(itt.chain.from_iterable([
-            coll.ddata[kk]['ref'] for kk in keys
-        ]))
-        and ii in [0, len(ref0) - 1]
-    ]
+    lref = list(set([
+        rr for kk in keys
+        for rr in coll.ddata[kk]['ref']
+        if rr not in refbs
+        and rr in ref0
+    ]))
 
     # ----------
     # unused options
 
     if ref_com is None:
-        if len(lrcom) > 0:
+        if len(lref) > 0:
             msg = (
                 f"\nPossible common ref for data {keys} and subkey '{kd0}':\n"
-                + "\n".join([f"\t- {rr}" for rr in lrcom])
+                + "\n".join([f"\t- {rr}" for rr in lref])
                 + "\nIf you wish to use one, specify with ref_com=..."
             )
             warnings.warn(msg)
@@ -834,11 +834,10 @@ def _submesh_ref_com(
         # --------------
         # if ref_com
 
-        lok = [rr[0] for rr in lrcom]
         ref_com = ds._generic_check._check_var(
             ref_com, 'ref_com',
             types=str,
-            allowed=lok,
+            allowed=lref,
         )
 
         # -----------

--- a/bsplines2d/_class02_plot_as_profile2d.py
+++ b/bsplines2d/_class02_plot_as_profile2d.py
@@ -142,6 +142,7 @@ def plot_as_profile2d(
                 keybs=v0['keybs'],
                 # ref vector
                 dref_vector=dref_vectorZ,
+                dref_vector_name='dref_vectorZ',
                 ref_vector_strategy=ref_vector_strategy,
                 uniform=uniform,
                 # details
@@ -563,16 +564,18 @@ def _get_dkey(
     if ndim >= 3:
         keyZ = coll2.get_ref_vector(
             ref=lr1d[0],
+            dref_vector_name='dref_vectorZ',
             **dref_vectorZ,
         )[3]
         # uniform = ds._plot_as_array._check_uniform_lin(
-            # k0=keyZ, ddata=coll2.ddata,
+        # k0=keyZ, ddata=coll2.ddata,
         # )
         # if not uniform:
-            # keyZ = None
+        # keyZ = None
         if ndim == 4:
             keyU = coll2.get_ref_vector(
                 ref=lr1d[1],
+                dref_vector_name='dref_vectorU',
                 **dref_vectorU,
             )[3]
 
@@ -580,8 +583,14 @@ def _get_dkey(
         'deg': deg,
         'interp': interp,
         'key': kdata,
-        'keyX': coll2.get_ref_vector(ref=rX)[3],
-        'keyY': coll2.get_ref_vector(ref=rY)[3],
+        'keyX': coll2.get_ref_vector(
+            ref=rX,
+            dref_vector_name='rX (bspline2d)',
+        )[3],
+        'keyY': coll2.get_ref_vector(
+            ref=rY,
+            dref_vector_name='rY(bspline2d)',
+        )[3],
         'keyZ': keyZ,
         'keyU': keyU,
     }
@@ -782,6 +791,7 @@ def _plot_submesh(
     keybs=None,
     # ref vetcor
     dref_vector=None,
+    dref_vector_name=None,
     ref_vector_strategy=None,
     uniform=None,
     # plot_details
@@ -850,6 +860,7 @@ def _plot_submesh(
         keybs=keybs,
         collax=collax,
         dref_vector=dref_vector,
+        dref_vector_name=dref_vector_name,
         ref_vector_strategy=ref_vector_strategy,
         plot_details=plot_details,
     )
@@ -947,7 +958,7 @@ def _plot_submesh(
 
         if dvminmax.get('data', {}).get('min') is not None:
             ax.set_ylim(bottom=dvminmax['data']['min'])
-        if  dvminmax.get('data', {}).get('min') is not None:
+        if dvminmax.get('data', {}).get('min') is not None:
             ax.set_ylim(top=dvminmax['data']['max'])
 
     return collax, dgroup
@@ -961,6 +972,7 @@ def _plot_profile2d_polar_add_radial(
     collax=None,
     # ref_vector
     dref_vector=None,
+    dref_vector_name=None,
     ref_vector_strategy=None,
     # details
     plot_details=None,
@@ -1019,7 +1031,10 @@ def _plot_profile2d_polar_add_radial(
     # ----
     # reft
 
-    refc = [rr for rr in coll.ddata[key]['ref'] if rr in coll.ddata[kr2d]['ref']]
+    refc = [
+        rr for rr in coll.ddata[key]['ref']
+        if rr in coll.ddata[kr2d]['ref']
+    ]
     if len(refc) == 1:
         refc = refc[0]
     else:
@@ -1030,6 +1045,7 @@ def _plot_profile2d_polar_add_radial(
         keys=[key, kr2d],
         ref=refc,
         strategy=ref_vector_strategy,
+        dref_vector_name=dref_vector_name,
         **dref_vector,
     )[1:]
 

--- a/bsplines2d/_class11_plot.py
+++ b/bsplines2d/_class11_plot.py
@@ -493,12 +493,24 @@ def _plot_profiles2d_prepare(
     refmap = coll2.ddata[keymap]['ref']
     dkeys = {
         'key': keymap,
-        'keyX': coll2.get_ref_vector(key0=keymap, ref=refmap[-2])[3],
-        'keyY': coll2.get_ref_vector(key0=keymap, ref=refmap[-1])[3],
+        'keyX': coll2.get_ref_vector(
+            key0=keymap,
+            ref=refmap[-2],
+            dref_vector_name=f"keymap='{keymap}' refmap[-2]='{refmap[-2]}'",
+        )[3],
+        'keyY': coll2.get_ref_vector(
+            key0=keymap,
+            ref=refmap[-1],
+            dref_vector_name=f"keymap='{keymap}' refmap[-1]='{refmap[-1]}'",
+        )[3],
         'keyZ': None,
     }
     if ndim == 3:
-        keyZ = coll2.get_ref_vector(key0=keymap, ref=refmap[0])[3]
+        keyZ = coll2.get_ref_vector(
+            key0=keymap,
+            ref=refmap[0],
+            dref_vector_name=f"keymap='{keymap}' refmap[0]='{refmap[0]}'",
+        )[3]
         import datastock as ds
         uniform = ds._plot_as_array._check_uniform_lin(
             k0=keyZ, ddata=coll2.ddata,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ keywords = [
     "data", "analysis", "interactive", "bsplines", "Collection", "mesh",
 ]
 # for datastock >= 0.0.56 + end of life of 3.9
-requires-python = ">=3.10"
+# scipy 1.15.3 and 1.16.0 have no wheel for python 3.14
+requires-python = ">=3.10,<3.14"
 dependencies = [
     "scipy<1.16.0",    # until https://github.com/ToFuProject/bsplines2d/issues/126 solved
     "contourpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ keywords = [
 # for datastock >= 0.0.56 + end of life of 3.9
 requires-python = ">=3.10"
 dependencies = [
+    "scipy<1.16.0",    # until https://github.com/ToFuProject/bsplines2d/issues/126 solved
     "contourpy",
     'datastock>=0.0.56',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,11 @@ maintainers = [
 keywords = [
     "data", "analysis", "interactive", "bsplines", "Collection", "mesh",
 ]
-requires-python = ">=3.8"
+# for datastock >= 0.0.56 + end of life of 3.9
+requires-python = ">=3.10"
 dependencies = [
     "contourpy",
-    'datastock>=0.0.55',
+    'datastock>=0.0.56',
 ]
 
 


### PR DESCRIPTION
Main changes:
-----------------

* `datastock >= 0.0.56`
* `python >= 3.10`
* propagated `dref_vector_name` for better wraning msg in `datastock`, see https://github.com/ToFuProject/datastock/pull/241
* minor clean-up

Issues:
--------

Fixes, in `devel`:
* #144 
* #145 