### PR TITLE
[#126] Attempt at fixing evaluate_spline for `scipy >= 1.16.0`

### DIFF
--- a/bsplines2d/_class02_bsplines_rect.py
+++ b/bsplines2d/_class02_bsplines_rect.py
@@ -17,7 +17,26 @@ from . import _utils_bsplines
 from . import _class02_bsplines_operators_rect
 
 
-if hasattr(scpinterp, '_bspl'):
+# Should work for scipy >= 1.15.0
+# see https://github.com/ToFuProject/bsplines2d/pull/147
+if (
+    hasattr(scpinterp, '_bsplines')
+    and hasattr(scpinterp._bsplines, '_dierckx')
+    and hasattr(scpinterp._bsplines._dierckx, 'evaluate_spline')
+):
+
+    def evaluate_spline(t, c, k, xp, nu, extrapolate, out):
+        out[...] = scpinterp._bsplines._dierckx.evaluate_spline(
+            t,     # 1d contiguous array of floats
+            c,     # 2d contiguous array of floats
+            k,     # int
+            xp,    # 1d contiguous array of floats
+            nu,    # int
+            extrapolate,   # bool
+        )
+        return
+
+elif hasattr(scpinterp, '_bspl'):
 
     if hasattr(scpinterp._bspl, 'evaluate_spline'):
         evaluate_spline = scpinterp._bspl.evaluate_spline
@@ -54,23 +73,6 @@ if hasattr(scpinterp, '_bspl'):
                 indices_k1d,
                 out,
             )
-
-# Should work for scipy >= 1.16.0
-elif (
-    hasattr(scpinterp, '_bsplines')
-    and hasattr(scpinterp._bsplines, '_dierckx')
-    and hasattr(scpinterp._bsplines._dierckx, 'evaluate_spline')
-):
-
-    def evaluate_spline(t, c, k, xp, nu, extrapolate, out):
-        out[:, 0] = scpinterp._bsplines._dierckx.evaluate_spline(
-            t,     # 1d contiguous array of floats
-            c,     # 2d contiguous array of floats
-            k,     # int
-            nu,    # int
-            extrapolate,   # bool
-        )
-        return
 
 else:
     msg = f"scipy {scp.__version__} has no evaluate_spline"

--- a/bsplines2d/_class02_bsplines_rect.py
+++ b/bsplines2d/_class02_bsplines_rect.py
@@ -25,16 +25,19 @@ if (
     and hasattr(scpinterp._bsplines._dierckx, 'evaluate_spline')
 ):
 
-    def evaluate_spline(t, c, k, xp, nu, extrapolate, out):
-        out[...] = scpinterp._bsplines._dierckx.evaluate_spline(
-            t,     # 1d contiguous array of floats
-            c,     # 2d contiguous array of floats
-            k,     # int
-            xp,    # 1d contiguous array of floats
-            nu,    # int
-            extrapolate,   # bool
-        )
-        return
+    if scp.__version__.startswith('1.15'):
+        evaluate_spline = scpinterp._bsplines._dierckx.evaluate_spline
+    else:
+        def evaluate_spline(t, c, k, xp, nu, extrapolate, out):
+            out[...] = scpinterp._bsplines._dierckx.evaluate_spline(
+                t,     # 1d contiguous array of floats
+                c,     # 2d contiguous array of floats
+                k,     # int
+                xp,    # 1d contiguous array of floats
+                nu,    # int
+                extrapolate,   # bool
+            )
+            return
 
 elif hasattr(scpinterp, '_bspl'):
 

--- a/bsplines2d/_class02_bsplines_rect.py
+++ b/bsplines2d/_class02_bsplines_rect.py
@@ -8,6 +8,7 @@ import warnings
 
 # Common
 import numpy as np
+import scipy as scp
 import scipy.interpolate as scpinterp
 
 
@@ -16,41 +17,64 @@ from . import _utils_bsplines
 from . import _class02_bsplines_operators_rect
 
 
-if hasattr(scpinterp._bspl, 'evaluate_spline'):
-    evaluate_spline = scpinterp._bspl.evaluate_spline
+if hasattr(scpinterp, '_bspl'):
 
-else:
-    msg = (
-        "\n\n"
-        "bsplines2d using a new version of scipy"
-        " with no scpinterp._bspl.evaluate_spline()\n"
-        "Instead using scpinterp._bspl.evaluate_ndspline()\n"
-        "Prototypal and not thoroughly tested!\n"
-    )
-    warnings.warn(msg)
+    if hasattr(scpinterp._bspl, 'evaluate_spline'):
+        evaluate_spline = scpinterp._bspl.evaluate_spline
+
+    else:
+        msg = (
+            "\n\n"
+            "bsplines2d using a new version of scipy"
+            " with no scpinterp._bspl.evaluate_spline()\n"
+            "Instead using scpinterp._bspl.evaluate_ndspline()\n"
+            "Prototypal and not thoroughly tested!\n"
+        )
+        warnings.warn(msg)
+
+        def evaluate_spline(t, c, k, xp, nu, extrapolate, out):
+            ndim = 1
+            c1 = c.reshape(c.shape[:ndim] + (-1,))
+            num_c_tr = c1.shape[-1]
+            strides_c1 = [stride // c.dtype.itemsize for stride in c.strides]
+            indices_k1d = np.unravel_index(
+                np.arange((k+1)**ndim),
+                (k+1,)*ndim,
+            )[0][:, None]
+            return scpinterp._bspl.evaluate_ndbspline(
+                xp[:, None],
+                t[None, :],
+                np.array([t.size], dtype=np.int32),
+                np.array([k], dtype=np.int32),
+                np.array([nu], dtype=np.int32),
+                extrapolate,
+                c.ravel(),
+                num_c_tr,
+                np.array(strides_c1, dtype=np.intp),
+                indices_k1d,
+                out,
+            )
+
+# Should work for scipy >= 1.16.0
+elif (
+    hasattr(scpinterp, '_bsplines')
+    and hasattr(scpinterp._bsplines, '_dierckx')
+    and hasattr(scpinterp._bsplines._dierckx, 'evaluate_spline')
+):
 
     def evaluate_spline(t, c, k, xp, nu, extrapolate, out):
-        ndim = 1
-        c1 = c.reshape(c.shape[:ndim] + (-1,))
-        num_c_tr = c1.shape[-1]
-        strides_c1 = [stride // c.dtype.itemsize for stride in c.strides]
-        indices_k1d = np.unravel_index(
-            np.arange((k+1)**ndim),
-            (k+1,)*ndim,
-        )[0][:, None]
-        return scpinterp._bspl.evaluate_ndbspline(
-            xp[:, None],
-            t[None, :],
-            np.array([t.size], dtype=np.int32),
-            np.array([k], dtype=np.int32),
-            np.array([nu], dtype=np.int32),
-            extrapolate,
-            c.ravel(),
-            num_c_tr,
-            np.array(strides_c1, dtype=np.intp),
-            indices_k1d,
-            out,
+        out[:, 0] = scpinterp._bsplines._dierckx.evaluate_spline(
+            t,     # 1d contiguous array of floats
+            c,     # 2d contiguous array of floats
+            k,     # int
+            nu,    # int
+            extrapolate,   # bool
         )
+        return
+
+else:
+    msg = f"scipy {scp.__version__} has no evaluate_spline"
+    raise Exception(msg)
 
 
 # ################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ keywords = [
 # scipy 1.15.3 and 1.16.0 have no wheel for python 3.14
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "scipy<1.16.0",    # until https://github.com/ToFuProject/bsplines2d/issues/126 solved
+    "scipy",    # see https://github.com/ToFuProject/bsplines2d/pull/147
     "contourpy",
     'datastock>=0.0.56',
 ]


### PR DESCRIPTION
Main changes:
----------------

Rectangular bsplines get evaluated, when `details=True` by a different function depending on the `scipy` version:

Looks like the main change happened at `scipy >= 1.15.0`


| scipy version | `_bspl.evaluate_spline()`   | `_bspl.evaluate_ndbspline` |  `_bsplines._dierckx.evaluate_spline()`   |
| ---------------|-----------------------------|-----------------------------|-------------------------------------------|
| 1.14.0            |                    1                     |                    1                     |                         0                                    |
| 1.14.1            |                    1                     |                    1                     |                         0                                    |
| 1.15.0            |                    0                     |                    1                     |                 1       (takes 7th `out` arg)      |
| 1.15.3            |                    0                     |                    1                     |                  1      (takes 7th `out` arg)      |
| 1.16.0            |                     0                    |                    0                     |              1   (only 6 args, returns `out`)    |
| 1.16.3            |                     0                    |                    0                     |              1   (only 6 args, returns `out`)    |
| 1.17.0            |                     0                    |                    0                     |               1  (only 6 args, returns `out`)   |



Issues:
-------

Fixes, in devel, #126 